### PR TITLE
Ignore JSON field ordering in tests

### DIFF
--- a/src/Clash/WaveDrom/Internal.hs
+++ b/src/Clash/WaveDrom/Internal.hs
@@ -517,7 +517,9 @@ data WaveDrom = WaveDrom
   , signal :: [Value]
   }
   deriving Generic
+  deriving Eq
   deriving anyclass ToJSON
+  deriving anyclass FromJSON
 
 flattenUnnamed :: [Value] -> [Value]
 flattenUnnamed =

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -17,6 +17,7 @@ import           Control.DeepSeq
 import           Control.Exception              ( evaluate )
 import           Data.Aeson                     ( (.=)
                                                 , object
+                                                , decode
                                                 )
 import           Data.Bits
 import qualified Data.ByteString.Lazy          as LBS
@@ -160,8 +161,15 @@ readmeSignal =
 ----------------------------------------------------------------
 
 signalTest :: TestName -> LBS.ByteString -> TestTree
-signalTest name =
-  goldenVsStringDiff name
-                     (\ref new -> ["diff", "-u", ref, new])
-                     ("test/data" </> name <.> "json")
-    . pure
+signalTest name input =
+  goldenTest
+    name
+    (LBS.readFile ("test/data" </> name <.> "json"))
+    (pure input)
+    (\a b -> return $
+      if (decode a :: Maybe WaveDrom) == decode b then
+        Nothing
+      else
+        Just "Did not match"
+    )
+    (const (pure ()))


### PR DESCRIPTION
Order isn't consistent across version of aeson, and this seemed like the preferable option vs restricting to a particular version or using different golden files per version.